### PR TITLE
ci: SHA-pin actions/checkout to v6.0.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install bats
         run: |

--- a/action.yaml
+++ b/action.yaml
@@ -44,7 +44,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         fetch-depth: 1
         token: ${{ inputs.TOKEN || github.token }}


### PR DESCRIPTION
Pins the nested actions/checkout (composite action.yaml + tests) to v6.0.3 (df4cb1c). Required so consumers under a sha_pinning_required policy can run this action; the unpinned actions/checkout@v6 was being rejected (e.g. qte77/qte77 repo-registry).

Generated with Claude <noreply@anthropic.com>